### PR TITLE
sched: Add other commits left out during CAF's 3.18 stable merge

### DIFF
--- a/kernel/sched/core.c
+++ b/kernel/sched/core.c
@@ -5031,6 +5031,28 @@ try_to_wake_up(struct task_struct *p, unsigned int state, int wake_flags)
 
 	success = 1; /* we're going to change ->state */
 
+	/*
+	 * Ensure we load p->on_rq _after_ p->state, otherwise it would
+	 * be possible to, falsely, observe p->on_rq == 0 and get stuck
+	 * in smp_cond_load_acquire() below.
+	 *
+	 * sched_ttwu_pending()                 try_to_wake_up()
+	 *   [S] p->on_rq = 1;                  [L] P->state
+	 *       UNLOCK rq->lock  -----.
+	 *                              \
+	 *				 +---   RMB
+	 * schedule()                   /
+	 *       LOCK rq->lock    -----'
+	 *       UNLOCK rq->lock
+	 *
+	 * [task p]
+	 *   [S] p->state = UNINTERRUPTIBLE     [L] p->on_rq
+	 *
+	 * Pairs with the UNLOCK+LOCK on rq->lock from the
+	 * last wakeup of our task and the schedule that got our task
+	 * current.
+	 */
+	smp_rmb();
 	if (p->on_rq && ttwu_remote(p, wake_flags))
 		goto stat;
 

--- a/kernel/sched/proc.c
+++ b/kernel/sched/proc.c
@@ -97,10 +97,13 @@ long calc_load_fold_active(struct rq *this_rq)
 static unsigned long
 calc_load(unsigned long load, unsigned long exp, unsigned long active)
 {
-	load *= exp;
-	load += active * (FIXED_1 - exp);
-	load += 1UL << (FSHIFT - 1);
-	return load >> FSHIFT;
+	unsigned long newload;
+
+	newload = load * exp + active * (FIXED_1 - exp);
+	if (active >= load)
+		newload += FIXED_1-1;
+
+	return newload / FIXED_1;
 }
 
 #ifdef CONFIG_NO_HZ_COMMON


### PR DESCRIPTION
These commits were left out by CAF during the 3.18.31 -> 3.18.71 merge,
when they shouldn't have been because they picked clean. Add them back
to avoid future merge conflicts and be closer to stable.

fb4064a ("sched/core: Fix a race between try_to_wake_up() and a woken up task")
8d2ba3f ("sched/loadavg: Fix loadavg artifacts on fully idle and on fully loaded systems")

Signed-off-by: ahmedradaideh <ahmed.radaideh@gmail.com>