### PR TITLE
cpuidle: Add other commits left out during CAF's 3.18 stable merge

### DIFF
--- a/drivers/cpuidle/cpuidle.c
+++ b/drivers/cpuidle/cpuidle.c
@@ -127,7 +127,7 @@ int cpuidle_enter_state(struct cpuidle_device *dev, struct cpuidle_driver *drv,
 	time_end = ktime_get();
 	trace_cpu_idle_rcuidle(PWR_EVENT_EXIT, dev->cpu);
 
-	if (!cpuidle_state_is_coupled(dev, drv, entered_state))
+	if (!cpuidle_state_is_coupled(dev, drv, index))
 		local_irq_enable();
 
 	diff = ktime_to_us(ktime_sub(time_end, time_start));
@@ -355,6 +355,8 @@ static void __cpuidle_unregister_device(struct cpuidle_device *dev)
 	list_del(&dev->device_list);
 	per_cpu(cpuidle_devices, dev->cpu) = NULL;
 	module_put(drv->owner);
+
+	dev->registered = 0;
 }
 
 static void __cpuidle_device_init(struct cpuidle_device *dev)


### PR DESCRIPTION
These commits were left out by CAF during the 3.18.31 -> 3.18.71 merge,
when they shouldn't have been because they picked clean. Add them back
to avoid future merge conflicts and be closer to stable.

2506cfa42ac63c5dd4176dd19331fe35822ac2f8 ("cpuidle: Fix cpuidle_state_is_coupled() argument in cpuidle_enter()")
887f64e66000496335a0bd894d57f45a6b37076b ("cpuidle: Indicate when a device has been unregistered")

Signed-off-by: ahmedradaideh <ahmed.radaideh@gmail.com>