### PR TITLE
qHMP: Fix a "Re-Definition" Error

### DIFF
--- a/include/linux/sched.h
+++ b/include/linux/sched.h
@@ -404,12 +404,9 @@ extern signed long schedule_timeout_uninterruptible(signed long timeout);
 asmlinkage void schedule(void);
 extern void schedule_preempt_disabled(void);
 
-extern long io_schedule_timeout(long timeout);
+long io_schedule_timeout(long timeout);
 
-static inline void io_schedule(void)
-{
-	io_schedule_timeout(MAX_SCHEDULE_TIMEOUT);
-}
+void io_schedule(void);
 
 struct nsproxy;
 struct user_namespace;


### PR DESCRIPTION
Note:
On building with "msm8937-perf_defconfig" (without any other changes), an error shows up. In fact, building with qHMP enabled, results in the error. This commit fixes the error.

Error:
/home/shoaib0597/Android/CAF-8.1.0_Linux-3.18.y/kernel/sched/qhmp_core.c:6269:14: error: redefinition of 'io_schedule'
 void __sched io_schedule(void)
              ^
In file included from /home/shoaib0597/Android/CAF-8.1.0_Linux-3.18.y/arch/arm64/include/asm/compat.h:25:0,
                 from /home/shoaib0597/Android/CAF-8.1.0_Linux-3.18.y/arch/arm64/include/asm/stat.h:23,
                 from /home/shoaib0597/Android/CAF-8.1.0_Linux-3.18.y/include/linux/stat.h:5,
                 from /home/shoaib0597/Android/CAF-8.1.0_Linux-3.18.y/include/linux/module.h:10,
                 from /home/shoaib0597/Android/CAF-8.1.0_Linux-3.18.y/kernel/sched/qhmp_core.c:30:
/home/shoaib0597/Android/CAF-8.1.0_Linux-3.18.y/include/linux/sched.h:409:20: note: previous definition of 'io_schedule' was here
 static inline void io_schedule(void)
                    ^
/home/shoaib0597/Android/CAF-8.1.0_Linux-3.18.y/scripts/Makefile.build:257: recipe for target 'kernel/sched/qhmp_core.o' failed
make[3]: *** [kernel/sched/qhmp_core.o] Error 1
/home/shoaib0597/Android/CAF-8.1.0_Linux-3.18.y/scripts/Makefile.build:402: recipe for target 'kernel/sched' failed
make[2]: *** [kernel/sched] Error 2
/home/shoaib0597/Android/CAF-8.1.0_Linux-3.18.y/Makefile:965: recipe for target 'kernel' failed
make[1]: *** [kernel] Error 2
make[1]: *** Waiting for unfinished jobs....

Signed-off-by: Shoaib0597 <Shoaib0595@gmail.com>